### PR TITLE
Unexpected :ssl_closed message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## Hotfix [0.1.1] - 15.05.2019
+### Fixed
+- OTP21 `:ssl_closed` message handling in Producer.
+
 ## Release [0.1.0] - 25.04.2019
 ### Added
 - First released version with SQS support.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your dependencies in mix file:
 ```elixir
 def deps do
     [
-        {:ex_queue_bus_client, git: "https://github.com/lets-talk/ex-queue-bus-client.git", tag: "0.1"}
+        {:ex_queue_bus_client, git: "https://github.com/lets-talk/ex-queue-bus-client.git", tag: "0.1.1"}
     ]
 end
 ```

--- a/lib/ex_queue_bus_client/sqs/producer.ex
+++ b/lib/ex_queue_bus_client/sqs/producer.ex
@@ -63,4 +63,12 @@ defmodule ExQueueBusClient.SQS.Producer do
 
     {:noreply, messages, %{state | demand: new_demand}}
   end
+
+  @doc """
+  This is a workaround to avoid failure from ssl_closed
+  message after upgrade OTP.
+  """
+  def handle_info({:ssl_closed, _}, state) do
+    {:noreply, [], state}
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExQueueBusClient.Mixfile do
   def project do
     [
       app: :ex_queue_bus_client,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Problem

After update OTP to version 21 we began to receive :ssl_closed message in GenStage producer that reads from SQS.

### Solution

Implement :ssl_closed message handler that does nothing in this case to pretend failure.