### PR TITLE
Change provider type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ erl_crash.dump
 *.ez
 
 /config/*.secret.exs
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## [unreleased]
+### Changed
+- Provider type passing to handler from atom to string.
+
 ## Release [0.2.0] - 16.05.2019
 ### Added
 - CircleCI integration.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,10 @@
 use Mix.Config
 
-config :ex_queue_bus_client,
-  queue: "communication_bus_develop",
-  event_handler: ExQueueBusClient.EventHandler
+config :ex_aws,
+  access_key_id: ["${AWS_ACCESS_KEY}", :instance_role],
+  secret_access_key: ["${AWS_SECRET_KEY}", :instance_role],
+  region: "${AWS_REGION}"
 
-import_config "dev.secret.exs"
+config :ex_queue_bus_client,
+  queue: "${SQS_QUEUE_NAME}",
+  event_handler: ExQueueBusClient.EventHandler

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,6 +5,5 @@ config :ex_queue_bus_client,
   event_handler: ExQueueBusClient.EventHandlerMock
 
 config :ex_aws,
-  access_key_id:      [System.get_env("AWS_ACCESS_KEY"), :instance_role],
-  secret_access_key:  [System.get_env("AWS_SECRET_KEY"), :instance_role]
-
+  access_key_id: [System.get_env("AWS_ACCESS_KEY"), :instance_role],
+  secret_access_key: [System.get_env("AWS_SECRET_KEY"), :instance_role]

--- a/lib/ex_queue_bus_client/behaviours/event_handler_behaviour.ex
+++ b/lib/ex_queue_bus_client/behaviours/event_handler_behaviour.ex
@@ -1,6 +1,4 @@
 defmodule ExQueueBusClient.EventHandlerBehaviour do
-  @type event :: String.t()
-  @type provider :: :letstalk | :nuntium | :hangout
-
-  @callback handle_event(event, provider, map()) :: :process | :skip
+  @callback handle_event(event :: binary, provider :: binary, payload :: map()) ::
+              :process | :skip
 end

--- a/test/sqs/consumer_test.exs
+++ b/test/sqs/consumer_test.exs
@@ -25,8 +25,8 @@ defmodule ExQueueBusClient.SQS.ConsumerTest do
       {:consumer, state, subscribe_to: []} = Consumer.init(opts)
 
       EventHandlerMock
-      |> expect(:handle_event, fn("create_message", :letstalk, %{"content" => "M1"}) -> :process end)
-      |> expect(:handle_event, fn("create_message", :letstalk, %{"content" => "M2"}) -> :skip end)
+      |> expect(:handle_event, fn("create_message", "letstalk", %{"content" => "M1"}) -> :process end)
+      |> expect(:handle_event, fn("create_message", "letstalk", %{"content" => "M2"}) -> :skip end)
 
       assert {:noreply, [], ^state} = Consumer.handle_events(messages, self(), state)
       assert_receive :deleted


### PR DESCRIPTION
## Change provider type

**ISSUE #7**

Now we are receiving provider as a string and converting it to existing atom, but assuming that provider is a dynamic parameter this approach induce an error during conversion.  To solve this we just want to let it stay string all the way down to the recipient and in a Handler make sure that we pattern match correctly.