### PR TITLE
New message format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ erl_crash.dump
 *.ez
 
 /config/*.secret.exs
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+## [unreleased]
+### Changed
+- How messages are sent via SQS, structure, attributes.
+- How messages are receieved and handled.
+- Provider now is a string argument of handle_event/3.
+
 ## Release [0.2.0] - 16.05.2019
 ### Added
 - CircleCI integration.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,10 @@
 use Mix.Config
 
-config :ex_queue_bus_client,
-  queue: "communication_bus_develop",
-  event_handler: ExQueueBusClient.EventHandler
+config :ex_aws,
+  access_key_id: ["${AWS_ACCESS_KEY}", :instance_role],
+  secret_access_key: ["${AWS_SECRET_KEY}", :instance_role],
+  region: "${AWS_REGION}"
 
-import_config "dev.secret.exs"
+config :ex_queue_bus_client,
+  queue: "${SQS_QUEUE_NAME}",
+  event_handler: ExQueueBusClient.EventHandler

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,6 +5,5 @@ config :ex_queue_bus_client,
   event_handler: ExQueueBusClient.EventHandlerMock
 
 config :ex_aws,
-  access_key_id:      [System.get_env("AWS_ACCESS_KEY"), :instance_role],
-  secret_access_key:  [System.get_env("AWS_SECRET_KEY"), :instance_role]
-
+  access_key_id: [System.get_env("AWS_ACCESS_KEY"), :instance_role],
+  secret_access_key: [System.get_env("AWS_SECRET_KEY"), :instance_role]

--- a/lib/ex_queue_bus_client.ex
+++ b/lib/ex_queue_bus_client.ex
@@ -7,8 +7,14 @@ defmodule ExQueueBusClient do
 
   @behaviour ExQueueBusClient.SenderBehaviour
 
-  def send_action(action) do
+  def send_action(action = {_, _}) do
     SQS.send_message(queue(), action)
+  end
+
+  def send_action(action) do
+    action
+    |> ExQueueBusClient.SerializableAction.serialize()
+    |> send_action()
   end
 
   def queue do
@@ -17,7 +23,7 @@ defmodule ExQueueBusClient do
 
   defprotocol SerializableAction do
     @fallback_to_any true
-    @spec serialize(any) :: String.t() | :error
+    @spec serialize(any) :: {binary, [map]}
     def serialize(data)
   end
 end

--- a/lib/ex_queue_bus_client/behaviours/event_handler_behaviour.ex
+++ b/lib/ex_queue_bus_client/behaviours/event_handler_behaviour.ex
@@ -1,6 +1,3 @@
 defmodule ExQueueBusClient.EventHandlerBehaviour do
-  @type event :: String.t()
-  @type provider :: :letstalk | :nuntium | :hangout
-
-  @callback handle_event(event, provider, map()) :: :process | :skip
+  @callback handle_event(binary, binary, map()) :: :process | :skip
 end

--- a/lib/ex_queue_bus_client/behaviours/ex_queue_bus_client_sender_behaviour.ex
+++ b/lib/ex_queue_bus_client/behaviours/ex_queue_bus_client_sender_behaviour.ex
@@ -6,6 +6,6 @@ defmodule ExQueueBusClient.SenderBehaviour do
   @doc """
   Send a serialized action
   """
-  @callback send_action(String.t()) :: {:ok} | {:error, String.t()}
-
+  @callback send_action({binary, Keyword.t()} | term) ::
+              {binary, [map]} | {:ok, term()} | {:error, term()}
 end

--- a/lib/ex_queue_bus_client/behaviours/ex_queue_bus_client_sender_behaviour.ex
+++ b/lib/ex_queue_bus_client/behaviours/ex_queue_bus_client_sender_behaviour.ex
@@ -6,6 +6,6 @@ defmodule ExQueueBusClient.SenderBehaviour do
   @doc """
   Send a serialized action
   """
-  @callback send_action({binary, Keyword.t()} | term) ::
+  @callback send_action({binary, [map]} | term) ::
               {binary, [map]} | {:ok, term()} | {:error, term()}
 end

--- a/lib/ex_queue_bus_client/serializable_actions/any.ex
+++ b/lib/ex_queue_bus_client/serializable_actions/any.ex
@@ -1,5 +1,5 @@
 defimpl ExQueueBusClient.SerializableAction, for: Any do
   def serialize(_) do
-    Poison.encode!(%{event: "Undefined", provider: "Undefined", payload: %{}})
+    {Poison.encode!(%{event: "Undefined", provider: "Undefined", payload: %{}}), []}
   end
 end

--- a/lib/ex_queue_bus_client/serializable_actions/map.ex
+++ b/lib/ex_queue_bus_client/serializable_actions/map.ex
@@ -1,0 +1,15 @@
+defimpl ExQueueBusClient.SerializableAction, for: Map do
+  def serialize(%{payload: payload, provider: provider, event: event}) do
+    {
+      Poison.encode!(payload),
+      [
+        %{name: "event", data_type: :string, value: event},
+        %{name: "provider", data_type: :string, value: provider}
+      ]
+    }
+  end
+
+  def serialize(payload) do
+    {Poison.encode!(payload), []}
+  end
+end

--- a/lib/ex_queue_bus_client/serializable_actions/string.ex
+++ b/lib/ex_queue_bus_client/serializable_actions/string.ex
@@ -1,0 +1,5 @@
+defimpl ExQueueBusClient.SerializableAction, for: BitString do
+  def serialize(data) do
+    {data, []}
+  end
+end

--- a/lib/ex_queue_bus_client/serializable_actions/tuple.ex
+++ b/lib/ex_queue_bus_client/serializable_actions/tuple.ex
@@ -1,5 +1,22 @@
 defimpl ExQueueBusClient.SerializableAction, for: Tuple do
   def serialize({name, provider, payload = %{}}) do
-    Poison.encode!(%{event: name, provider: provider, body: payload})
+    {
+      Poison.encode!(payload),
+      [
+        %{name: "event", data_type: :string, value: name},
+        %{name: "provider", data_type: :string, value: provider}
+      ]
+    }
+  end
+
+  def serialize({name, provider, payload = %{}, target}) do
+    {
+      Poison.encode!(payload),
+      [
+        %{name: "event", data_type: :string, value: name},
+        %{name: "provider", data_type: :string, value: provider},
+        %{name: "target", data_type: :string, value: target}
+      ]
+    }
   end
 end

--- a/lib/ex_queue_bus_client/sqs.ex
+++ b/lib/ex_queue_bus_client/sqs.ex
@@ -18,12 +18,12 @@ defmodule ExQueueBusClient.SQS do
   @doc """
   Send message to AWS SQS.
   """
-  @spec send_message(String.t(), String.t()) :: {:ok, term} | {:error, term}
-  def send_message(queue, message) do
+  @spec send_message(String.t(), {String.t(), [map]}) :: {:ok, term} | {:error, term}
+  def send_message(queue, {message, attributes}) do
     Logger.info("Sending message to SQS: #{inspect(message)}.")
 
     queue
-    |> ExAws.SQS.send_message(message)
+    |> ExAws.SQS.send_message(message, message_attributes: attributes)
     |> ExAws.request()
   end
 

--- a/lib/ex_queue_bus_client/sqs/producer.ex
+++ b/lib/ex_queue_bus_client/sqs/producer.ex
@@ -5,7 +5,7 @@ defmodule ExQueueBusClient.SQS.Producer do
 
   def start_link(opts) do
     opts = Keyword.put(opts, :sqs, opts[:sqs] || SQS)
-    GenStage.start_link(__MODULE__, opts, [name: __MODULE__])
+    GenStage.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
   def init(sqs: sqs, queue_name: queue_name) do
@@ -35,7 +35,10 @@ defmodule ExQueueBusClient.SQS.Producer do
   def handle_info(:get_messages, state) do
     aws_resp =
       state.queue
-      |> state.sqs.receive_message(max_number_of_messages: min(state.demand, 10))
+      |> state.sqs.receive_message(
+        message_attribute_names: [:provider, :target, :event],
+        max_number_of_messages: min(state.demand, 10)
+      )
 
     messages =
       case aws_resp do

--- a/test/ex_queue_bus_client_test.exs
+++ b/test/ex_queue_bus_client_test.exs
@@ -3,7 +3,12 @@ defmodule ExQueueBusClientTest do
   doctest ExQueueBusClient
 
   @tag :integration
-  test "AWS SQS responds ok after sending message" do
+  test "AWS SQS responds ok after sending message as tuple" do
+    assert {:ok, _} = ExQueueBusClient.send_action({"some action", []})
+  end
+
+  @tag :integration
+  test "AWS SQS responds ok after sending message as term" do
     assert {:ok, _} = ExQueueBusClient.send_action("some action")
   end
 end

--- a/test/serializable_actions/map_test.exs
+++ b/test/serializable_actions/map_test.exs
@@ -1,0 +1,39 @@
+defmodule ExQueueBusClient.MapTest do
+  use ExUnit.Case
+  import ExQueueBusClient.SerializableAction
+
+  test "map serializes correctly without attributes" do
+    expected = {
+      Poison.encode!(%{data: 123}),
+      []
+    }
+
+    assert serialize(%{data: 123}) == expected
+  end
+
+  test "map serializes with attributes" do
+    expected = {
+      Poison.encode!(%{data: 123}),
+      [
+        %{
+          name: "event",
+          data_type: :string,
+          value: "some_action"
+        },
+        %{
+          name: "provider",
+          data_type: :string,
+          value: "nuntium"
+        }
+      ]
+    }
+
+    actual = %{
+      payload: %{data: 123},
+      event: "some_action",
+      provider: "nuntium"
+    }
+
+    assert serialize(actual) == expected
+  end
+end

--- a/test/serializable_actions/string_test.exs
+++ b/test/serializable_actions/string_test.exs
@@ -1,0 +1,13 @@
+defmodule ExQueueBusClient.StringTest do
+  use ExUnit.Case
+  import ExQueueBusClient.SerializableAction
+
+  test "string serializes correctly without attributes" do
+    expected = {
+      "some_action",
+      []
+    }
+
+    assert serialize("some_action") == expected
+  end
+end

--- a/test/serializable_actions/tuple_test.exs
+++ b/test/serializable_actions/tuple_test.exs
@@ -2,9 +2,50 @@ defmodule ExQueueBusClient.TupleTest do
   use ExUnit.Case
   import ExQueueBusClient.SerializableAction
 
-  test "tuple serializes correctly" do
-    expected = %{event: "some_action", provider: "nuntium", body: %{data: 123}}
-    actual = serialize({:some_action, "nuntium", %{data: 123}})
-    assert Poison.decode!(actual, keys: :atoms!) == expected
+  test "tuple serializes correctly without target" do
+    expected = {
+      %{data: 123},
+      [
+        %{
+          name: "event",
+          data_type: :string,
+          value: "some_action"
+        },
+        %{
+          name: "provider",
+          data_type: :string,
+          value: "nuntium"
+        }
+      ]
+    }
+
+    actual = serialize({"some_action", "nuntium", %{data: 123}})
+    assert {Poison.decode!(elem(actual, 0), keys: :atoms!), elem(actual, 1)} == expected
+  end
+
+  test "tuple serializes correctly with target" do
+    expected = {
+      %{data: 123},
+      [
+        %{
+          name: "event",
+          data_type: :string,
+          value: "some_action"
+        },
+        %{
+          name: "provider",
+          data_type: :string,
+          value: "nuntium"
+        },
+        %{
+          name: "target",
+          data_type: :string,
+          value: "letstalk"
+        }
+      ]
+    }
+
+    actual = serialize({"some_action", "nuntium", %{data: 123}, "letstalk"})
+    assert {Poison.decode!(elem(actual, 0), keys: :atoms!), elem(actual, 1)} == expected
   end
 end

--- a/test/sqs/consumer_test.exs
+++ b/test/sqs/consumer_test.exs
@@ -25,8 +25,10 @@ defmodule ExQueueBusClient.SQS.ConsumerTest do
       {:consumer, state, subscribe_to: []} = Consumer.init(opts)
 
       EventHandlerMock
-      |> expect(:handle_event, fn("create_message", :letstalk, %{"content" => "M1"}) -> :process end)
-      |> expect(:handle_event, fn("create_message", :letstalk, %{"content" => "M2"}) -> :skip end)
+      |> expect(:handle_event, fn "create_message", "letstalk", %{"content" => "M1"} ->
+        :process
+      end)
+      |> expect(:handle_event, fn "create_message", "letstalk", %{"content" => "M2"} -> :skip end)
 
       assert {:noreply, [], ^state} = Consumer.handle_events(messages, self(), state)
       assert_receive :deleted
@@ -37,13 +39,18 @@ defmodule ExQueueBusClient.SQS.ConsumerTest do
   defp build_message(event, body) do
     %{
       attributes: [],
-      body: Poison.encode!(%{
-        event: event,
-        provider: "letstalk",
-        body: %{content: body}
-      }),
+      body: Poison.encode!(%{content: body}),
       md5_of_body: "2d8514fd568c4038110b487bc5cba784",
-      message_attributes: [],
+      message_attributes: %{
+        "provider" => %{
+          name: "provider",
+          value: "letstalk"
+        },
+        "event" => %{
+          name: "event",
+          value: event
+        }
+      },
       message_id: "8c1c0a71-20d6-4c44-b872-b032f51315d8",
       receipt_handle: "some long bullshit"
     }


### PR DESCRIPTION
## New message format

**ISSUE #6**

Due to our infrastructure changes, we need to pass *provider* and *event* attributes to message attributes of AWS queue message. Also we add one more optional attribute *target* in case we are sending message directly to the certain recipient service.