### PR TITLE
New communication format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+## [unreleased]
+### Fixed
+- Configuration system is now callback based.
+### Added
+- Support for more message attributes.
+### Changed
+- Message format.
+
 ## Hotfix [1.0.1] - 05.07.2019
 ### Fixed
 - Dependency injection for testing with mocks. Ensure to

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Several message attributes are defined and supported by `ExQueueBusClient` these
 - `:event` of type `:string`
 - `:resource` of type `:string`
 - `:provider` of type `:string`
-- `:role` of type `:"String.Array"`
+- `:roles` of type `:"String.Array"`
 - `:version` of type `:number`
 - `:organization` of type `:string`
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,7 +6,6 @@ config :ex_aws,
   region: "${AWS_REGION}"
 
 config :ex_queue_bus_client,
-  queue: "${SQS_QUEUE_NAME}",
-  event_handler: ExQueueBusClient.EventHandler,
   sns_client: ExAws.SNS,
-  aws_client: ExAws
+  aws_client: ExAws,
+  config_agent: ExQueueBusClient.BusSupervisor.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -6,6 +6,6 @@ config :ex_aws,
   region: "us-west-1"
 
 config :ex_queue_bus_client,
-  queue: "${SQS_QUEUE_NAME}",
   sns_client: ExAws.SNS,
-  aws_client: ExAws
+  aws_client: ExAws,
+  config_agent: ExQueueBusClient.BusSupervisor.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,11 +1,9 @@
 use Mix.Config
 
 config :ex_queue_bus_client,
-  do_not_start_tree: true,
-  event_handler: ExQueueBusClient.EventHandlerMock,
   sns_client: ExQueueBusClient.SNSClientMock,
   aws_client: ExQueueBusClient.AWSClientMock,
-  sns_topic: "test-topic"
+  config_agent: ExQueueBusClient.ConfigMock
 
 config :ex_aws,
   access_key_id: [System.get_env("AWS_ACCESS_KEY"), :instance_role],

--- a/lib/ex_queue_bus_client.ex
+++ b/lib/ex_queue_bus_client.ex
@@ -21,19 +21,12 @@ defmodule ExQueueBusClient do
   end
 
   @doc """
-  AWS SQS queue name to use if SQS is configured.
-  """
-  @spec queue() :: binary
-  def queue do
-    Application.get_env(:ex_queue_bus_client, :queue) || "probando"
-  end
-
-  @doc """
   AWS SNS topic to use if SNS is configured.
   """
   @spec sns_topic() :: binary()
   def sns_topic do
-    Application.get_env(:ex_queue_bus_client, :sns_topic)
+    config()
+    |> Keyword.get(:sns_topic_arn)
   end
 
   @doc """
@@ -41,7 +34,7 @@ defmodule ExQueueBusClient do
   """
   @spec sns_client() :: :atom
   def sns_client do
-    Application.get_env(:ex_queue_bus_client, :sns_client) || ExAws.SNS
+    Application.get_env(:ex_queue_bus_client, :sns_client)
   end
 
   @doc """
@@ -49,15 +42,23 @@ defmodule ExQueueBusClient do
   """
   @spec aws_client() :: :atom
   def aws_client do
-    Application.get_env(:ex_queue_bus_client, :aws_client) || ExAws
+    Application.get_env(:ex_queue_bus_client, :aws_client)
+  end
+
+  def config do
+    config_agent = Application.get_env(:ex_queue_bus_client, :config_agent)
+    config_agent.config()
   end
 
   defp tx_transport do
-    Application.get_env(:ex_queue_bus_client, :send_via)
+    config()
+    |> Keyword.get(:send_via)
   end
 
   defp send_via(:sqs, action) do
-    SQS.send_message(queue(), action)
+    config()
+    |> Keyword.get(:sqs_queue_name)
+    |> SQS.send_message(action)
   end
 
   defp send_via(:sns, action) do

--- a/lib/ex_queue_bus_client/application.ex
+++ b/lib/ex_queue_bus_client/application.ex
@@ -3,24 +3,8 @@ defmodule ExQueueBusClient.Application do
 
   use Application
 
-  alias ExQueueBusClient.SQS.{Producer, Consumer}
-
   def start(_type, _args) do
-    queue = ExQueueBusClient.queue()
-
-    do_not_start_tree = Application.get_env(:ex_queue_bus_client, :do_not_start_tree)
-
-    children = if do_not_start_tree do
-      []
-    else 
-      [
-        {Producer, [queue_name: queue]},
-        Consumer.child_spec(:sqsc1, [queue_name: queue, producers: [Producer], name: :sqs_consumer_1]),
-        Consumer.child_spec(:sqsc2, [queue_name: queue, producers: [Producer], name: :sqs_consumer_2])
-      ]
-    end
-
     opts = [strategy: :one_for_one, name: ExQueueBusClient.Supervisor]
-    Supervisor.start_link(children, opts)
+    Supervisor.start_link([], opts)
   end
 end

--- a/lib/ex_queue_bus_client/bus.ex
+++ b/lib/ex_queue_bus_client/bus.ex
@@ -1,0 +1,55 @@
+defmodule ExQueueBusClient.Bus do
+  @moduledoc """
+  Defines a transport and ways of sending and receiving
+  messages between micro-services.
+
+  When used, Bus expects `:otp_app` OTP application that uses
+  this library and that has transport configuration to be provided,
+  also two options `:send_via` which defines a way to send messages
+  that can be SNS or SQS and `:receive_with` which defines a way
+  to receive messages, only SQS for now. For example, the bus:
+
+    defmodule MyApp.Bus do
+      use ExQueueBusClient.Bus,
+        otp_app: :my_app,
+        event_handler: MyApp.EventHandler,
+        send_via: :sns,
+        receive_with: :sqs
+    end
+
+  Could be configured with:
+
+    config :my_app, MyApp.Bus,
+      consumers_count: 5,
+      sqs_queue_name: "my-app-queue",
+      sns_topic_arn: "my-app-topic"
+  """
+
+  @doc false
+  defmacro __using__(opts) do
+    quote bind_quoted: [opts: opts] do
+      @behaviour ExQueueBusClient.Bus
+
+      @otp_app Keyword.get(opts, :otp_app)
+      @send_via Keyword.get(opts, :send_via)
+      @receive_with Keyword.get(opts, :receive_with, :sqs)
+      @event_handler Keyword.get(opts, :event_handler)
+
+      def start_link(opts \\ []) do
+        ExQueueBusClient.BusSupervisor.start_link(
+          __MODULE__,
+          @otp_app,
+          @event_handler,
+          @receive_with,
+          @send_via,
+          opts
+        )
+      end
+    end
+  end
+
+  @callback start_link(opts :: Keyword.t()) ::
+              {:ok, pid}
+              | {:error, {:already_started, pid}}
+              | {:error, term}
+end

--- a/lib/ex_queue_bus_client/bus_supervisor.ex
+++ b/lib/ex_queue_bus_client/bus_supervisor.ex
@@ -1,0 +1,78 @@
+defmodule ExQueueBusClient.BusSupervisor do
+  @moduledoc false
+  use Supervisor
+
+  alias ExQueueBusClient.SQS.{Producer, Consumer}
+
+  @doc """
+  Starts gen stage system supervisor.
+  """
+  def start_link(bus, otp_app, handler, receive_with, send_via, opts) do
+    name = Keyword.get(opts, :name, bus)
+
+    Supervisor.start_link(__MODULE__, {name, bus, otp_app, handler, receive_with, send_via, opts},
+      name: name
+    )
+  end
+
+  @doc """
+  Reads Bus configuration from Application environment.
+  """
+  def config(bus, otp_app) do
+    Application.get_env(otp_app, bus, [])
+  end
+
+  ## Callbacks
+
+  @doc false
+  @impl true
+  def init({_name, bus, otp_app, handler, receive_with, send_via, _opts}) do
+    config =
+      bus
+      |> config(otp_app)
+      |> Keyword.put(:event_handler, handler)
+      |> Keyword.put(:send_via, send_via)
+
+    children = [
+      {ExQueueBusClient.BusSupervisor.Config, config} | receive_mechanism(receive_with, config)
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one, max_restarts: 0)
+  end
+
+  defp receive_mechanism(:sqs, config) do
+    consumers_count = Keyword.get(config, :consumers_count, 2)
+    consumers_count = if consumers_count <= 0, do: 2, else: consumers_count
+
+    queue = config[:sqs_queue_name]
+    handler = config[:event_handler]
+
+    [{Producer, [queue_name: queue]}] ++
+      for n <- 1..consumers_count, into: [] do
+        Consumer.child_spec("Consumer-#{n}",
+          queue_name: queue,
+          producers: [Producer],
+          event_handler: handler
+        )
+      end
+  end
+
+  defp receive_mechanism(_, _), do: raise("Unsupported receiving mechanism.")
+
+  # This is a simple Agent that stores config in it's state.
+  defmodule Config do
+    @moduledoc false
+    use Agent
+
+    @callback start_link(config :: Keyword.t()) :: {:ok, pid} | {:error, term}
+    @callback config() :: Keyword.t()
+
+    def start_link(config) do
+      Agent.start_link(fn -> config end, name: ExQueueBusClient.Config)
+    end
+
+    def config do
+      Agent.get(ExQueueBusClient.Config, fn state -> state end)
+    end
+  end
+end

--- a/lib/ex_queue_bus_client/serializable_actions/map.ex
+++ b/lib/ex_queue_bus_client/serializable_actions/map.ex
@@ -32,7 +32,7 @@ defimpl ExQueueBusClient.SerializableAction, for: Map do
   end
 
   defp parse_attribute({:role, value}) do
-    %{name: "role", data_type: :"String.Array", value: Poison.encode!(value)}
+    %{name: "roles", data_type: :"String.Array", value: Poison.encode!(value)}
   end
 
   defp parse_attribute({:version, value}) do

--- a/lib/ex_queue_bus_client/serializable_actions/map.ex
+++ b/lib/ex_queue_bus_client/serializable_actions/map.ex
@@ -1,15 +1,51 @@
 defimpl ExQueueBusClient.SerializableAction, for: Map do
-  def serialize(%{payload: payload, provider: provider, event: event}) do
+  def serialize(message = %{payload: payload, provider: _, event: event}) do
+    [resource, event] =
+      case String.split(event, ".") do
+        [resource, event] -> [resource, event]
+        [event] -> [nil, event]
+      end
+
     {
       Poison.encode!(payload),
-      [
-        %{name: "event", data_type: :string, value: event},
-        %{name: "provider", data_type: :string, value: provider}
-      ]
+      message
+      |> Map.put(:event, event)
+      |> Map.put_new(:resource, resource)
+      |> Map.put_new(:version, 1)
+      |> Enum.map(&parse_attribute/1)
+      |> Enum.filter(& &1)
     }
   end
 
   def serialize(payload) do
     {Poison.encode!(payload), []}
   end
+
+  defp parse_attribute({_, nil}), do: nil
+
+  defp parse_attribute({:provider, value}) do
+    %{name: "provider", data_type: :string, value: value}
+  end
+
+  defp parse_attribute({:event, value}) do
+    %{name: "event", data_type: :string, value: value}
+  end
+
+  defp parse_attribute({:role, value}) do
+    %{name: "role", data_type: :"String.Array", value: Poison.encode!(value)}
+  end
+
+  defp parse_attribute({:version, value}) do
+    %{name: "version", data_type: :number, value: value}
+  end
+
+  defp parse_attribute({:organization, value}) do
+    %{name: "organization", data_type: :string, value: value}
+  end
+
+  defp parse_attribute({:resource, value}) do
+    %{name: "resource", data_type: :string, value: value}
+  end
+
+  defp parse_attribute(_), do: nil
 end

--- a/lib/ex_queue_bus_client/sqs/consumer.ex
+++ b/lib/ex_queue_bus_client/sqs/consumer.ex
@@ -2,22 +2,22 @@ defmodule ExQueueBusClient.SQS.Consumer do
   use GenStage
   alias ExQueueBusClient.SQS
 
-  @event_handler Application.get_env(:ex_queue_bus_client, :event_handler)
-
   def start_link(opts) do
     init_opts = [
       queue: opts[:queue_name],
       producers: opts[:producers],
+      event_handler: opts[:event_handler],
       sqs: opts[:sqs] || SQS
     ]
 
-    GenStage.start_link(__MODULE__, init_opts, name: opts[:name] || __MODULE__)
+    GenStage.start_link(__MODULE__, init_opts)
   end
 
-  def init(queue: queue_name, producers: producers, sqs: sqs) do
+  def init(queue: queue_name, producers: producers, event_handler: event_handler, sqs: sqs) do
     state = %{
       queue: queue_name,
-      sqs: sqs
+      sqs: sqs,
+      event_handler: event_handler
     }
 
     subscriptions = Enum.map(producers, &{&1, [max_demand: 10]})

--- a/lib/ex_queue_bus_client/sqs/producer.ex
+++ b/lib/ex_queue_bus_client/sqs/producer.ex
@@ -3,7 +3,7 @@ defmodule ExQueueBusClient.SQS.Producer do
 
   alias ExQueueBusClient.SQS
 
-  @message_attributes [:version, :provider, :target, :event, :resource, :organization, :role]
+  @message_attributes [:version, :provider, :target, :event, :resource, :organization, :roles]
 
   def start_link(opts) do
     opts = Keyword.put(opts, :sqs, opts[:sqs] || SQS)

--- a/lib/ex_queue_bus_client/sqs/producer.ex
+++ b/lib/ex_queue_bus_client/sqs/producer.ex
@@ -3,6 +3,8 @@ defmodule ExQueueBusClient.SQS.Producer do
 
   alias ExQueueBusClient.SQS
 
+  @message_attributes [:version, :provider, :target, :event, :resource, :organization, :role]
+
   def start_link(opts) do
     opts = Keyword.put(opts, :sqs, opts[:sqs] || SQS)
     GenStage.start_link(__MODULE__, opts, name: __MODULE__)
@@ -36,7 +38,7 @@ defmodule ExQueueBusClient.SQS.Producer do
     aws_resp =
       state.queue
       |> state.sqs.receive_message(
-        message_attribute_names: [:provider, :target, :event],
+        message_attribute_names: @message_attributes,
         max_number_of_messages: min(state.demand, 10)
       )
 

--- a/test/bus_test.exs
+++ b/test/bus_test.exs
@@ -1,0 +1,43 @@
+defmodule ExQueueBusClient.BusTest do
+  use ExUnit.Case, async: false
+
+  defmodule DummyBus do
+    use ExQueueBusClient.Bus,
+      otp_app: :ex_queue_bus_client,
+      event_handler: ExQueueBusClient.EventHandler,
+      send_via: :sns,
+      receive_with: :sqs
+  end
+
+  @settings [consumers_count: 3, sns_topic_arn: "test-topic", sqs_queue_name: "test-queue"]
+
+  setup do
+    Application.put_env(:ex_queue_bus_client, ExQueueBusClient.BusTest.DummyBus, @settings)
+    :ok
+  end
+
+  describe "module that uses Bus" do
+    test "it has a start_link/1 function exported" do
+      assert function_exported?(DummyBus, :start_link, 1)
+    end
+
+    test "it starts bus supervisor with children and correct config" do
+      assert {:ok, pid} = DummyBus.start_link()
+
+      assert [
+               {"Consumer-3", _, _, _},
+               {"Consumer-2", _, _, _},
+               {"Consumer-1", _, _, _},
+               {ExQueueBusClient.SQS.Producer, _, _, _},
+               {ExQueueBusClient.BusSupervisor.Config, _, _, _}
+             ] = Supervisor.which_children(pid)
+
+      config =
+        @settings
+        |> Keyword.put(:event_handler, ExQueueBusClient.EventHandler)
+        |> Keyword.put(:send_via, :sns)
+
+      assert ^config = ExQueueBusClient.BusSupervisor.Config.config()
+    end
+  end
+end

--- a/test/serializable_actions/map_test.exs
+++ b/test/serializable_actions/map_test.exs
@@ -18,20 +18,42 @@ defmodule ExQueueBusClient.MapTest do
         %{
           name: "event",
           data_type: :string,
-          value: "some_action"
+          value: "action"
+        },
+        %{
+          name: "organization",
+          data_type: :string,
+          value: "bci"
         },
         %{
           name: "provider",
           data_type: :string,
           value: "nuntium"
+        },
+        %{
+          name: "resource",
+          data_type: :string,
+          value: "resource"
+        },
+        %{
+          name: "role",
+          data_type: :"String.Array",
+          value: Poison.encode!(["integration"])
+        },
+        %{
+          name: "version",
+          data_type: :number,
+          value: 1
         }
       ]
     }
 
     actual = %{
       payload: %{data: 123},
-      event: "some_action",
-      provider: "nuntium"
+      event: "resource.action",
+      provider: "nuntium",
+      role: ["integration"],
+      organization: "bci"
     }
 
     assert serialize(actual) == expected

--- a/test/serializable_actions/map_test.exs
+++ b/test/serializable_actions/map_test.exs
@@ -36,7 +36,7 @@ defmodule ExQueueBusClient.MapTest do
           value: "resource"
         },
         %{
-          name: "role",
+          name: "roles",
           data_type: :"String.Array",
           value: Poison.encode!(["integration"])
         },

--- a/test/sns_test.exs
+++ b/test/sns_test.exs
@@ -4,7 +4,8 @@ defmodule ExQueueBusClient.SNSTest do
   alias ExQueueBusClient.{
     SNS,
     SNSClientMock,
-    AWSClientMock
+    AWSClientMock,
+    ConfigMock
   }
 
   import Mox
@@ -15,7 +16,10 @@ defmodule ExQueueBusClient.SNSTest do
     test "it makes a correct request to AWS" do
       query = %ExAws.Operation.Query{}
       payload = %{"content" => "Hello"}
-      topic = ExQueueBusClient.sns_topic()
+      topic = "test-topic"
+
+      ConfigMock
+      |> expect(:config, fn -> [sns_topic_arn: topic] end)
 
       attributes = [
         %{

--- a/test/sqs/consumer_test.exs
+++ b/test/sqs/consumer_test.exs
@@ -14,7 +14,7 @@ defmodule ExQueueBusClient.SQS.ConsumerTest do
   setup do
     messages =
       ["M1", "M2"]
-      |> Enum.map(&build_message("create_message", &1))
+      |> Enum.map(&build_message("message", "create", &1))
 
     %{messages: messages}
   end
@@ -31,10 +31,10 @@ defmodule ExQueueBusClient.SQS.ConsumerTest do
       {:consumer, state, subscribe_to: []} = Consumer.init(opts)
 
       EventHandlerMock
-      |> expect(:handle_event, fn "create_message", "letstalk", %{"content" => "M1"} ->
+      |> expect(:handle_event, fn "message.create", "letstalk", %{"content" => "M1"} ->
         :process
       end)
-      |> expect(:handle_event, fn "create_message", "letstalk", %{"content" => "M2"} -> :skip end)
+      |> expect(:handle_event, fn "message.create", "letstalk", %{"content" => "M2"} -> :skip end)
 
       assert {:noreply, [], ^state} = Consumer.handle_events(messages, self(), state)
       assert_receive :deleted
@@ -42,7 +42,7 @@ defmodule ExQueueBusClient.SQS.ConsumerTest do
     end
   end
 
-  defp build_message(event, body) do
+  defp build_message(resource, event, body) do
     %{
       attributes: [],
       body: Poison.encode!(%{content: body}),
@@ -55,6 +55,10 @@ defmodule ExQueueBusClient.SQS.ConsumerTest do
         "event" => %{
           name: "event",
           value: event
+        },
+        "resource" => %{
+          name: "resource",
+          value: resource
         }
       },
       message_id: "8c1c0a71-20d6-4c44-b872-b032f51315d8",

--- a/test/sqs/consumer_test.exs
+++ b/test/sqs/consumer_test.exs
@@ -21,7 +21,13 @@ defmodule ExQueueBusClient.SQS.ConsumerTest do
 
   describe "handle_events/3" do
     test "processes message", %{messages: messages} do
-      opts = [queue: "test", producers: [], sqs: SqsMock]
+      opts = [
+        queue: "test",
+        producers: [],
+        event_handler: ExQueueBusClient.EventHandlerMock,
+        sqs: SqsMock
+      ]
+
       {:consumer, state, subscribe_to: []} = Consumer.init(opts)
 
       EventHandlerMock

--- a/test/sqs/producer_test.exs
+++ b/test/sqs/producer_test.exs
@@ -20,7 +20,10 @@ defmodule ExQueueBusClient.SQS.ProducerTest do
 
       attributes = [
         %{name: "provider", data_type: :string, value: "letstalk"},
-        %{name: "event", data_type: :string, value: "message-create"}
+        %{name: "event", data_type: :string, value: "create"},
+        %{name: "resource", data_type: :string, value: "message"},
+        %{name: "version", data_type: :string, value: "1"},
+        %{name: "role", data_type: :"String.Array", value: "['foo', 'bar']"}
       ]
 
       queue |> SQS.create_queue() |> ExAws.request()
@@ -46,7 +49,10 @@ defmodule ExQueueBusClient.SQS.ProducerTest do
             m,
             %{
               "provider" => "letstalk",
-              "event" => "message-create"
+              "event" => "create",
+              "resource" => "message",
+              "version" => "1",
+              "role" => "['foo', 'bar']"
             }
           }
         end
@@ -60,7 +66,10 @@ defmodule ExQueueBusClient.SQS.ProducerTest do
             m.body,
             %{
               "provider" => m.message_attributes["provider"].value,
-              "event" => m.message_attributes["event"].value
+              "event" => m.message_attributes["event"].value,
+              "resource" => m.message_attributes["resource"].value,
+              "version" => m.message_attributes["version"].value,
+              "role" => m.message_attributes["role"].value
             }
           }
         end)

--- a/test/sqs/producer_test.exs
+++ b/test/sqs/producer_test.exs
@@ -23,7 +23,8 @@ defmodule ExQueueBusClient.SQS.ProducerTest do
         %{name: "event", data_type: :string, value: "create"},
         %{name: "resource", data_type: :string, value: "message"},
         %{name: "version", data_type: :string, value: "1"},
-        %{name: "role", data_type: :"String.Array", value: "['foo', 'bar']"}
+        %{name: "roles", data_type: :"String.Array", value: "['foo', 'bar']"},
+        %{name: "target", data_type: :string, value: "ex_queue_bus_client"}
       ]
 
       queue |> SQS.create_queue() |> ExAws.request()
@@ -52,7 +53,8 @@ defmodule ExQueueBusClient.SQS.ProducerTest do
               "event" => "create",
               "resource" => "message",
               "version" => "1",
-              "role" => "['foo', 'bar']"
+              "roles" => "['foo', 'bar']",
+              "target" => "ex_queue_bus_client"
             }
           }
         end
@@ -69,7 +71,8 @@ defmodule ExQueueBusClient.SQS.ProducerTest do
               "event" => m.message_attributes["event"].value,
               "resource" => m.message_attributes["resource"].value,
               "version" => m.message_attributes["version"].value,
-              "role" => m.message_attributes["role"].value
+              "roles" => m.message_attributes["roles"].value,
+              "target" => m.message_attributes["target"].value
             }
           }
         end)

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,3 +1,4 @@
 Mox.defmock(ExQueueBusClient.EventHandlerMock, for: ExQueueBusClient.EventHandlerBehaviour)
 Mox.defmock(ExQueueBusClient.SNSClientMock, for: ExQueueBusClient.SNSClientBehaviour)
 Mox.defmock(ExQueueBusClient.AWSClientMock, for: ExQueueBusClient.AWSClientBehaviour)
+Mox.defmock(ExQueueBusClient.ConfigMock, for: ExQueueBusClient.BusSupervisor.Config)


### PR DESCRIPTION
## New communication format

**ISSUE #12** 

### Problems

1. The global council decided to change communication protocol between micro services at Let's Talk and now we have several message attributes such as `provider`, `resource`, `event`, `role`, `version` and `organization`. A lot of these attributes I don't receive in this lib and also the event attributed has been separated into resource and event that I should compound on reading.
2. Currently we don't send all the necessary attributes but we have to.
3. We have a wrong way organized library configuration.

### Solution
1. Implement the complete list of attributes to receive.
2. Give possibility to send all necessary attributes.
3. Some of these attributes should be set in configuration at the app level such as version, role, and provider.
4. Implement configuration based on `use` macro.

### Steps to follow
- [x] add more attributes to receive.
- [x] form event based on two attributes (event & resource).
- [x] add more attributes send.
- [ ] Give possibility to set some of the attributes at library configuration.
- [x] Change library configuration system.
