### PR TITLE
Bug fixes in config system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+## Hotfix [2.0.1] - 01.08.2019
+### Fixed
+- Use real modules when mocks are not defined without app env.
+
+### Added
+- Childspec for Bus.
+- Delegate `Bus.publish/1` to `ExQueueBusClient.send_action/1`.
+
 ## Release [2.0.0] - 31.07.2019
 ### Fixed
 - Configuration system is now callback based.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following to your dependencies in mix file:
 ```elixir
 def deps do
     [
-        {:ex_queue_bus_client, git: "https://github.com/lets-talk/ex-queue-bus-client.git", tag: "2.0.0"}
+        {:ex_queue_bus_client, git: "https://github.com/lets-talk/ex-queue-bus-client.git", tag: "2.0.1"}
     ]
 end
 ```
@@ -39,7 +39,7 @@ To configure your bus you need to create a module like following:
 
 ```elixir
 defmodule MyApp.Bus do
-  use ExQueueBusClient,
+  use ExQueueBusClient.Bus,
     otp_app: :my_app,
     event_handler: MyApp.EventHandler,
     send_via: :sns,
@@ -130,7 +130,7 @@ This version supports:
 - AWS SNS for sending.
 
 ```elixir
-{:ok, _response} = ExQueueBusClient.send_action(%{
+{:ok, _response} = MyApp.Bus.publish(%{
   payload: %{content: "Hello folks !"},
   event: "message.create",
   provider: "my_app"

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ defmodule MyApp.Bus do
   use ExQueueBusClient.Bus,
     otp_app: :my_app,
     event_handler: MyApp.EventHandler,
-    send_via: :sns,
-    receive_with: :sqs
+    tx: :sns,
+    rx: :sqs
 end
 ```
 
-and according to your `:send_via` and `:receive_with` parameters add config to
+and according to your `:tx` and `:rx` parameters add config to
 your `Mix.Config`:
 
 ```elixir
@@ -98,7 +98,7 @@ Several message attributes are defined and supported by `ExQueueBusClient` these
 - `:provider` of type `:string`
 - `:roles` of type `:"String.Array"`
 - `:version` of type `:number`
-- `:organization` of type `:string`
+- `:realm` of type `:string`
 
 ### Event and Resource
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,8 +4,3 @@ config :ex_aws,
   access_key_id: ["${AWS_ACCESS_KEY}", :instance_role],
   secret_access_key: ["${AWS_SECRET_KEY}", :instance_role],
   region: "${AWS_REGION}"
-
-config :ex_queue_bus_client,
-  sns_client: ExAws.SNS,
-  aws_client: ExAws,
-  config_agent: ExQueueBusClient.BusSupervisor.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -4,8 +4,3 @@ config :ex_aws,
   access_key_id: ["${AWS_ACCESS_KEY}", :instance_role],
   secret_access_key: ["${AWS_SECRET_KEY}", :instance_role],
   region: "us-west-1"
-
-config :ex_queue_bus_client,
-  sns_client: ExAws.SNS,
-  aws_client: ExAws,
-  config_agent: ExQueueBusClient.BusSupervisor.Config

--- a/lib/ex_queue_bus_client.ex
+++ b/lib/ex_queue_bus_client.ex
@@ -55,7 +55,7 @@ defmodule ExQueueBusClient do
 
   defp tx_transport do
     config()
-    |> Keyword.get(:send_via)
+    |> Keyword.get(:tx)
   end
 
   defp send_via(:sqs, action) do

--- a/lib/ex_queue_bus_client.ex
+++ b/lib/ex_queue_bus_client.ex
@@ -34,7 +34,7 @@ defmodule ExQueueBusClient do
   """
   @spec sns_client() :: :atom
   def sns_client do
-    Application.get_env(:ex_queue_bus_client, :sns_client)
+    Application.get_env(:ex_queue_bus_client, :sns_client) || ExAws.SNS
   end
 
   @doc """
@@ -42,11 +42,14 @@ defmodule ExQueueBusClient do
   """
   @spec aws_client() :: :atom
   def aws_client do
-    Application.get_env(:ex_queue_bus_client, :aws_client)
+    Application.get_env(:ex_queue_bus_client, :aws_client) || ExAws
   end
 
   def config do
-    config_agent = Application.get_env(:ex_queue_bus_client, :config_agent)
+    config_agent =
+      Application.get_env(:ex_queue_bus_client, :config_agent) ||
+        ExQueueBusClient.BusSupervisor.Config
+
     config_agent.config()
   end
 

--- a/lib/ex_queue_bus_client/bus.ex
+++ b/lib/ex_queue_bus_client/bus.ex
@@ -45,11 +45,22 @@ defmodule ExQueueBusClient.Bus do
           opts
         )
       end
+
+      def child_spec(_) do
+        %{
+          id: __MODULE__,
+          start: {__MODULE__, :start_link, []}
+        }
+      end
     end
   end
+
+  @type event :: tuple | map | binary | any
 
   @callback start_link(opts :: Keyword.t()) ::
               {:ok, pid}
               | {:error, {:already_started, pid}}
               | {:error, term}
+
+  @callback child_spec(term) :: map
 end

--- a/lib/ex_queue_bus_client/bus.ex
+++ b/lib/ex_queue_bus_client/bus.ex
@@ -5,16 +5,16 @@ defmodule ExQueueBusClient.Bus do
 
   When used, Bus expects `:otp_app` OTP application that uses
   this library and that has transport configuration to be provided,
-  also two options `:send_via` which defines a way to send messages
-  that can be SNS or SQS and `:receive_with` which defines a way
+  also two options `:tx` which defines a way to send messages
+  that can be SNS or SQS and `:rx` which defines a way
   to receive messages, only SQS for now. For example, the bus:
 
     defmodule MyApp.Bus do
       use ExQueueBusClient.Bus,
         otp_app: :my_app,
         event_handler: MyApp.EventHandler,
-        send_via: :sns,
-        receive_with: :sqs
+        tx: :sns,
+        rx: :sqs
     end
 
   Could be configured with:
@@ -31,8 +31,8 @@ defmodule ExQueueBusClient.Bus do
       @behaviour ExQueueBusClient.Bus
 
       @otp_app Keyword.get(opts, :otp_app)
-      @send_via Keyword.get(opts, :send_via)
-      @receive_with Keyword.get(opts, :receive_with, :sqs)
+      @tx Keyword.get(opts, :tx)
+      @rx Keyword.get(opts, :rx, :sqs)
       @event_handler Keyword.get(opts, :event_handler)
 
       def start_link(opts \\ []) do
@@ -40,8 +40,8 @@ defmodule ExQueueBusClient.Bus do
           __MODULE__,
           @otp_app,
           @event_handler,
-          @receive_with,
-          @send_via,
+          @rx,
+          @tx,
           opts
         )
       end

--- a/lib/ex_queue_bus_client/bus.ex
+++ b/lib/ex_queue_bus_client/bus.ex
@@ -52,6 +52,10 @@ defmodule ExQueueBusClient.Bus do
           start: {__MODULE__, :start_link, []}
         }
       end
+
+      def publish(event) do
+        ExQueueBusClient.send_action(event)
+      end
     end
   end
 
@@ -63,4 +67,6 @@ defmodule ExQueueBusClient.Bus do
               | {:error, term}
 
   @callback child_spec(term) :: map
+
+  @callback publish(event) :: {:ok, term} | {:error, term}
 end

--- a/lib/ex_queue_bus_client/bus_supervisor.ex
+++ b/lib/ex_queue_bus_client/bus_supervisor.ex
@@ -7,12 +7,10 @@ defmodule ExQueueBusClient.BusSupervisor do
   @doc """
   Starts gen stage system supervisor.
   """
-  def start_link(bus, otp_app, handler, receive_with, send_via, opts) do
+  def start_link(bus, otp_app, handler, rx, tx, opts) do
     name = Keyword.get(opts, :name, bus)
 
-    Supervisor.start_link(__MODULE__, {name, bus, otp_app, handler, receive_with, send_via, opts},
-      name: name
-    )
+    Supervisor.start_link(__MODULE__, {name, bus, otp_app, handler, rx, tx, opts}, name: name)
   end
 
   @doc """
@@ -26,15 +24,15 @@ defmodule ExQueueBusClient.BusSupervisor do
 
   @doc false
   @impl true
-  def init({_name, bus, otp_app, handler, receive_with, send_via, _opts}) do
+  def init({_name, bus, otp_app, handler, rx, tx, _opts}) do
     config =
       bus
       |> config(otp_app)
       |> Keyword.put(:event_handler, handler)
-      |> Keyword.put(:send_via, send_via)
+      |> Keyword.put(:tx, tx)
 
     children = [
-      {ExQueueBusClient.BusSupervisor.Config, config} | receive_mechanism(receive_with, config)
+      {ExQueueBusClient.BusSupervisor.Config, config} | receive_mechanism(rx, config)
     ]
 
     Supervisor.init(children, strategy: :one_for_one, max_restarts: 0)

--- a/lib/ex_queue_bus_client/serializable_actions/map.ex
+++ b/lib/ex_queue_bus_client/serializable_actions/map.ex
@@ -31,7 +31,7 @@ defimpl ExQueueBusClient.SerializableAction, for: Map do
     %{name: "event", data_type: :string, value: value}
   end
 
-  defp parse_attribute({:role, value}) do
+  defp parse_attribute({:roles, value}) do
     %{name: "roles", data_type: :"String.Array", value: Poison.encode!(value)}
   end
 
@@ -39,8 +39,8 @@ defimpl ExQueueBusClient.SerializableAction, for: Map do
     %{name: "version", data_type: :number, value: value}
   end
 
-  defp parse_attribute({:organization, value}) do
-    %{name: "organization", data_type: :string, value: value}
+  defp parse_attribute({:realm, value}) do
+    %{name: "realm", data_type: :string, value: value}
   end
 
   defp parse_attribute({:resource, value}) do

--- a/lib/ex_queue_bus_client/sqs/producer.ex
+++ b/lib/ex_queue_bus_client/sqs/producer.ex
@@ -3,7 +3,7 @@ defmodule ExQueueBusClient.SQS.Producer do
 
   alias ExQueueBusClient.SQS
 
-  @message_attributes [:version, :provider, :target, :event, :resource, :organization, :roles]
+  @message_attributes [:version, :provider, :target, :event, :resource, :realm, :roles]
 
   def start_link(opts) do
     opts = Keyword.put(opts, :sqs, opts[:sqs] || SQS)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExQueueBusClient.Mixfile do
   def project do
     [
       app: :ex_queue_bus_client,
-      version: "2.0.0",
+      version: "2.0.1",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/bus_test.exs
+++ b/test/bus_test.exs
@@ -5,8 +5,8 @@ defmodule ExQueueBusClient.BusTest do
     use ExQueueBusClient.Bus,
       otp_app: :ex_queue_bus_client,
       event_handler: ExQueueBusClient.EventHandler,
-      send_via: :sns,
-      receive_with: :sqs
+      tx: :sns,
+      rx: :sqs
   end
 
   @settings [consumers_count: 3, sns_topic_arn: "test-topic", sqs_queue_name: "test-queue"]
@@ -43,7 +43,7 @@ defmodule ExQueueBusClient.BusTest do
       config =
         @settings
         |> Keyword.put(:event_handler, ExQueueBusClient.EventHandler)
-        |> Keyword.put(:send_via, :sns)
+        |> Keyword.put(:tx, :sns)
 
       assert ^config = ExQueueBusClient.BusSupervisor.Config.config()
     end

--- a/test/bus_test.exs
+++ b/test/bus_test.exs
@@ -21,6 +21,10 @@ defmodule ExQueueBusClient.BusTest do
       assert function_exported?(DummyBus, :start_link, 1)
     end
 
+    test "it has a child_spec/1 function exported" do
+      assert function_exported?(DummyBus, :child_spec, 1)
+    end
+
     test "it starts bus supervisor with children and correct config" do
       assert {:ok, pid} = DummyBus.start_link()
 

--- a/test/bus_test.exs
+++ b/test/bus_test.exs
@@ -25,6 +25,10 @@ defmodule ExQueueBusClient.BusTest do
       assert function_exported?(DummyBus, :child_spec, 1)
     end
 
+    test "it has a publish/1 function exported" do
+      assert function_exported?(DummyBus, :publish, 1)
+    end
+
     test "it starts bus supervisor with children and correct config" do
       assert {:ok, pid} = DummyBus.start_link()
 

--- a/test/ex_queue_bus_client_test.exs
+++ b/test/ex_queue_bus_client_test.exs
@@ -22,14 +22,14 @@ defmodule ExQueueBusClientTest do
   @tag :integration
   test "AWS SQS responds ok after sending message" do
     ConfigMock
-    |> expect(:config, 2, fn -> [send_via: :sqs, sqs_queue_name: "probando"] end)
+    |> expect(:config, 2, fn -> [tx: :sqs, sqs_queue_name: "probando"] end)
 
     assert {:ok, _} = ExQueueBusClient.send_action("some action")
   end
 
   test "sends message via SNS" do
     ConfigMock
-    |> expect(:config, 2, fn -> [send_via: :sns, sns_topic_arn: "test_topic"] end)
+    |> expect(:config, 2, fn -> [tx: :sns, sns_topic_arn: "test_topic"] end)
 
     SNSClientMock
     |> expect(:publish, fn _, _ -> %ExAws.Operation.Query{} end)
@@ -39,7 +39,7 @@ defmodule ExQueueBusClientTest do
 
   test "raises error when tx transport is not set" do
     ConfigMock
-    |> expect(:config, fn -> [send_via: nil] end)
+    |> expect(:config, fn -> [tx: nil] end)
 
     assert_raise RuntimeError, "Please set outgoing transport to use", fn ->
       ExQueueBusClient.send_action({"some_action", []})

--- a/test/serializable_actions/map_test.exs
+++ b/test/serializable_actions/map_test.exs
@@ -21,14 +21,14 @@ defmodule ExQueueBusClient.MapTest do
           value: "action"
         },
         %{
-          name: "organization",
-          data_type: :string,
-          value: "bci"
-        },
-        %{
           name: "provider",
           data_type: :string,
           value: "nuntium"
+        },
+        %{
+          name: "realm",
+          data_type: :string,
+          value: "bci"
         },
         %{
           name: "resource",
@@ -52,8 +52,8 @@ defmodule ExQueueBusClient.MapTest do
       payload: %{data: 123},
       event: "resource.action",
       provider: "nuntium",
-      role: ["integration"],
-      organization: "bci"
+      roles: ["integration"],
+      realm: "bci"
     }
 
     assert serialize(actual) == expected


### PR DESCRIPTION
## Bug fixes after 2.0.0 release

**ISSUE #14**

### Bugs

- `child_spec/1` is not implemented on Bus module.
- all the config settings are nil like SNS, AWS, Config modules. 

### Solutions

- [x] Define `child_spec/1`.
- [x] Use real modules always when Mock are not defined.
- [x] Delegate `send_action/1` to Bus module.
