### PR TITLE
Add type attribute to message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 CHANGELOG
 =========
 
+## [unreleased]
+### Added
+- New message attribute `Type` to handle.
+### Changed
+- Pass all attributes to handle_event function as a fourth argument.
+
 ## Hotfix [2.0.2] - 16.01.2020
 ### Fixed
 - Fix hacney version to get reed of ssl problem.
-
 
 ## Hotfix [2.0.1] - 01.08.2019
 ### Fixed

--- a/lib/ex_queue_bus_client/behaviours/event_handler_behaviour.ex
+++ b/lib/ex_queue_bus_client/behaviours/event_handler_behaviour.ex
@@ -1,3 +1,3 @@
 defmodule ExQueueBusClient.EventHandlerBehaviour do
-  @callback handle_event(binary, binary, map()) :: :process | :skip
+  @callback handle_event(binary, binary, map(), map()) :: :process | :skip
 end

--- a/lib/ex_queue_bus_client/serializable_actions/map.ex
+++ b/lib/ex_queue_bus_client/serializable_actions/map.ex
@@ -47,5 +47,9 @@ defimpl ExQueueBusClient.SerializableAction, for: Map do
     %{name: "resource", data_type: :string, value: value}
   end
 
+  defp parse_attribute({:type, value}) do
+    %{name: "type", data_type: :string, value: value}
+  end
+
   defp parse_attribute(_), do: nil
 end

--- a/lib/ex_queue_bus_client/sqs/consumer.ex
+++ b/lib/ex_queue_bus_client/sqs/consumer.ex
@@ -76,7 +76,7 @@ defmodule ExQueueBusClient.SQS.Consumer do
       end
 
     event
-    |> event_handler.handle_event(provider, body)
+    |> event_handler.handle_event(provider, body, message.message_attributes)
     |> post_process_message(message)
   end
 

--- a/lib/ex_queue_bus_client/sqs/producer.ex
+++ b/lib/ex_queue_bus_client/sqs/producer.ex
@@ -3,7 +3,7 @@ defmodule ExQueueBusClient.SQS.Producer do
 
   alias ExQueueBusClient.SQS
 
-  @message_attributes [:version, :provider, :target, :event, :resource, :realm, :roles]
+  @message_attributes [:version, :provider, :target, :event, :resource, :realm, :roles, :type]
 
   def start_link(opts) do
     opts = Keyword.put(opts, :sqs, opts[:sqs] || SQS)

--- a/test/serializable_actions/map_test.exs
+++ b/test/serializable_actions/map_test.exs
@@ -41,6 +41,11 @@ defmodule ExQueueBusClient.MapTest do
           value: Poison.encode!(["integration"])
         },
         %{
+          name: "type",
+          data_type: :string,
+          value: "command"
+        },
+        %{
           name: "version",
           data_type: :number,
           value: 1
@@ -53,7 +58,8 @@ defmodule ExQueueBusClient.MapTest do
       event: "resource.action",
       provider: "nuntium",
       roles: ["integration"],
-      realm: "bci"
+      realm: "bci",
+      type: "command"
     }
 
     assert serialize(actual) == expected

--- a/test/sqs/producer_test.exs
+++ b/test/sqs/producer_test.exs
@@ -24,7 +24,8 @@ defmodule ExQueueBusClient.SQS.ProducerTest do
         %{name: "resource", data_type: :string, value: "message"},
         %{name: "version", data_type: :string, value: "1"},
         %{name: "roles", data_type: :"String.Array", value: "['foo', 'bar']"},
-        %{name: "target", data_type: :string, value: "ex_queue_bus_client"}
+        %{name: "target", data_type: :string, value: "ex_queue_bus_client"},
+        %{name: "type", data_type: :string, value: "command"}
       ]
 
       queue |> SQS.create_queue() |> ExAws.request()
@@ -54,7 +55,8 @@ defmodule ExQueueBusClient.SQS.ProducerTest do
               "resource" => "message",
               "version" => "1",
               "roles" => "['foo', 'bar']",
-              "target" => "ex_queue_bus_client"
+              "target" => "ex_queue_bus_client",
+              "type" => "command"
             }
           }
         end
@@ -72,7 +74,8 @@ defmodule ExQueueBusClient.SQS.ProducerTest do
               "resource" => m.message_attributes["resource"].value,
               "version" => m.message_attributes["version"].value,
               "roles" => m.message_attributes["roles"].value,
-              "target" => m.message_attributes["target"].value
+              "target" => m.message_attributes["target"].value,
+              "type" => m.message_attributes["type"].value
             }
           }
         end)


### PR DESCRIPTION
## Add type attribute to message

### ISSUE #16 

### Description

We need to add new `Type` message attribute to be managed by the handler. It should be more flexible to pass all other attributes in a fourth parameter of the `handle_event` function. This change is incompatible with old versions of the library 😬 

### Steps to follow

- [x] Add some tests.
- [x] Add receiving of a `Type` attribute.
- [x] Pass all attributes as a fourth parameter of `handle_event` function. (Breaking)
